### PR TITLE
Improved matching of related domains for transip.*

### DIFF
--- a/AnnoyancesFilter/sections/cookies_whitelist.txt
+++ b/AnnoyancesFilter/sections/cookies_whitelist.txt
@@ -19,7 +19,7 @@ rusta.com#@#.cookie-content
 ! https://github.com/AdguardTeam/AdguardFilters/issues/17816
 @@||cdn.iubenda.com/cookie_solution/*.js$domain=slidetomac.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/17708
-@@||transip.nl/services/cookie-consent/
+@@||transip.*/services/cookie-consent/
 ! https://github.com/AdguardTeam/AdguardFilters/issues/17736
 @@||andreagaleazzi.com/wp-content/plugins/ag-cookie/js/eu-cookie-law.js
 ! https://github.com/AdguardTeam/AdguardFilters/issues/17705


### PR DESCRIPTION
On transip.* domains, e.g. transip.be or transip.eu, the following filter in cookies_general.txt prevents the site from accepting the user's acknowledgement of the cookie policy:
`/cookie-consent/*^$domain=~argeweb.nl`

There is an exception filter in cookies_whitelist.txt for just one of these domains:
`@@||transip.nl/services/cookie-consent/`

With the large number of related domains, I suggest a wildcard exception.